### PR TITLE
feat(audit): real pattern-based vulnerability scanner + SARIF/JSON output

### DIFF
--- a/compiler/src/audit/index.ts
+++ b/compiler/src/audit/index.ts
@@ -1,0 +1,2 @@
+export { scanPatterns, severityWeight } from './patterns.js';
+export type { Finding, Severity } from './patterns.js';

--- a/compiler/src/audit/patterns.ts
+++ b/compiler/src/audit/patterns.ts
@@ -1,0 +1,567 @@
+/**
+ * Pattern-based vulnerability detector for `cbang audit`.
+ *
+ * Walks the AST looking for code patterns commonly associated with
+ * security vulnerabilities. Unlike the structural checkers (ownership,
+ * effects, refinement) this is a heuristic scanner — findings should be
+ * reviewed by a human, but every finding points at a real construct in
+ * the source.
+ *
+ * Categories detected:
+ *   SEC001  hardcoded_secret     — credential-like name bound to a string literal
+ *   SEC002  weak_crypto          — call to MD5/SHA1/DES/RC4/MD4
+ *   SEC003  dangerous_eval       — eval/exec/system with non-literal argument
+ *   SEC004  insecure_url         — http:// literal (cleartext transport)
+ *   SEC005  path_traversal       — literal containing ".." path segment
+ *   SEC006  sql_concat           — query/execute called with a string-concat argument
+ *   SEC007  weak_random          — Math.random / rand() used where Crypto.random is expected
+ *   SEC008  todo_security        — string literal containing security TODO/FIXME marker
+ */
+
+import type {
+  Program,
+  TopLevelItem,
+  FunctionDecl,
+  ActorDecl,
+  ContractDecl,
+  ServerDecl,
+  ComponentDecl,
+  Block,
+  Stmt,
+  Expr,
+  LetStmt,
+  CallExpr,
+  MethodCallExpr,
+  StringInterpolationExpr,
+} from '../ast/index.js';
+import type { Span } from '../lexer/index.js';
+
+// ─── Public API ──────────────────────────────────────────────────
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export interface Finding {
+  code: string;
+  category: string;
+  severity: Severity;
+  message: string;
+  span: Span;
+  suggestion?: string;
+}
+
+export function scanPatterns(program: Program): Finding[] {
+  const scanner = new PatternScanner();
+  return scanner.scan(program);
+}
+
+// ─── Detection rules (data-driven) ───────────────────────────────
+
+/** Names suggesting credential storage when bound to a string literal. */
+const SECRET_NAME_RE = /(password|passwd|secret|api[_-]?key|access[_-]?key|private[_-]?key|auth[_-]?token|bearer|jwt[_-]?secret|credential|client[_-]?secret)/i;
+
+/** Cryptographically broken or weak primitives. */
+const WEAK_CRYPTO = new Set([
+  'md4', 'md5', 'sha1', 'des', 'des3', '3des', 'rc4', 'rc2',
+  'md5_hex', 'sha1_hex', 'md5sum', 'sha1sum',
+]);
+
+/** Calls treated as dynamic-code execution sinks. */
+const DANGEROUS_EVAL = new Set([
+  'eval', 'exec', 'execute', 'system', 'shell', 'spawn_shell',
+  'shell_exec', 'popen', 'compile_and_run',
+]);
+
+/** Calls that accept a SQL string and should never be string-concatenated. */
+const SQL_FUNCS = new Set([
+  'query', 'execute', 'exec_sql', 'sql', 'raw_query', 'unsafe_query',
+]);
+
+/** Weak randomness identifiers (any context they appear in is suspicious). */
+const WEAK_RANDOM = new Set([
+  'rand', 'random', 'math_random', 'mt_rand',
+]);
+
+/** Acceptable cleartext URL prefixes (these don't trigger SEC004). */
+const CLEARTEXT_ALLOWLIST = [
+  'http://localhost',
+  'http://127.0.0.1',
+  'http://0.0.0.0',
+  'http://[::1]',
+  'http://example.com',
+  'http://example.org',
+  'http://schemas.',           // XML namespaces
+  'http://www.w3.org',
+];
+
+const TODO_SEC_RE = /\b(TODO|FIXME|XXX|HACK)\b.*\b(security|secure|auth|vuln|inject|sanitize|escape|crypto|password|secret|token)\b/i;
+
+// ─── Scanner ─────────────────────────────────────────────────────
+
+class PatternScanner {
+  private findings: Finding[] = [];
+
+  scan(program: Program): Finding[] {
+    this.findings = [];
+    for (const item of program.items) {
+      this.scanItem(item);
+    }
+    // Sort by file position for deterministic output
+    this.findings.sort((a, b) => {
+      const al = a.span.start.line - b.span.start.line;
+      return al !== 0 ? al : a.span.start.column - b.span.start.column;
+    });
+    return this.findings;
+  }
+
+  private scanItem(item: TopLevelItem): void {
+    switch (item.kind) {
+      case 'FunctionDecl':
+        this.scanBlock((item as FunctionDecl).body);
+        break;
+      case 'ActorDecl':
+        this.scanActor(item as ActorDecl);
+        break;
+      case 'ContractDecl':
+        this.scanContract(item as ContractDecl);
+        break;
+      case 'ServerDecl':
+        this.scanServer(item as ServerDecl);
+        break;
+      case 'ComponentDecl':
+        this.scanBlock((item as ComponentDecl).body);
+        break;
+      // TypeDecl/EnumDecl/UseDecl/ModDecl/StateDecl have no executable body
+      default:
+        break;
+    }
+  }
+
+  private scanActor(decl: ActorDecl): void {
+    for (const m of decl.members) {
+      if (m.kind === 'FunctionDecl') this.scanBlock(m.body);
+      else if (m.kind === 'OnHandler') this.scanBlock(m.body);
+      else if (m.kind === 'InitDecl') this.scanBlock(m.body);
+      else if (m.kind === 'StateDecl' && m.initializer) this.scanExpr(m.initializer);
+    }
+  }
+
+  private scanContract(decl: ContractDecl): void {
+    for (const m of decl.members) {
+      if (m.kind === 'FunctionDecl') this.scanBlock(m.body);
+      else if (m.kind === 'InitDecl') this.scanBlock(m.body);
+      else if (m.kind === 'StateDecl' && m.initializer) this.scanExpr(m.initializer);
+    }
+  }
+
+  private scanServer(decl: ServerDecl): void {
+    for (const m of decl.members) {
+      if (m.kind === 'FunctionDecl') this.scanBlock(m.body);
+      else if (m.kind === 'StateDecl' && m.initializer) this.scanExpr(m.initializer);
+      else if (m.kind === 'FieldAssignment') this.scanExpr(m.value);
+    }
+  }
+
+  private scanBlock(block: Block): void {
+    for (const stmt of block.statements) this.scanStmt(stmt);
+  }
+
+  private scanStmt(stmt: Stmt): void {
+    switch (stmt.kind) {
+      case 'LetStmt':
+        this.checkHardcodedSecret(stmt);
+        this.scanExpr(stmt.initializer);
+        break;
+      case 'ExprStmt':
+        this.scanExpr(stmt.expr);
+        break;
+      case 'ReturnStmt':
+        if (stmt.value) this.scanExpr(stmt.value);
+        break;
+      case 'ReplyStmt':
+        this.scanExpr(stmt.value);
+        break;
+      case 'EmitStmt':
+        for (const a of stmt.args) this.scanExpr(a);
+        break;
+      case 'AssignStmt':
+        this.scanExpr(stmt.target);
+        this.scanExpr(stmt.value);
+        // Treat assignment to a credential-named field as a hardcoded secret.
+        if (
+          stmt.target.kind === 'FieldAccess' &&
+          SECRET_NAME_RE.test(stmt.target.field) &&
+          stmt.value.kind === 'StringLiteral' &&
+          stmt.value.value.length >= 8
+        ) {
+          this.report({
+            code: 'SEC001',
+            category: 'hardcoded_secret',
+            severity: 'high',
+            message: `Hardcoded credential assigned to '${stmt.target.field}'`,
+            span: stmt.span,
+            suggestion: 'Load secrets from env/secret-store, never commit literals.',
+          });
+        }
+        break;
+      case 'IfStmt':
+        this.scanExpr(stmt.condition);
+        this.scanBlock(stmt.then);
+        if (stmt.else_) {
+          if (stmt.else_.kind === 'IfStmt') this.scanStmt(stmt.else_);
+          else this.scanBlock(stmt.else_);
+        }
+        break;
+      case 'WhileStmt':
+        this.scanExpr(stmt.condition);
+        this.scanBlock(stmt.body);
+        break;
+      case 'ForStmt':
+        this.scanExpr(stmt.iterable);
+        this.scanBlock(stmt.body);
+        break;
+      case 'MatchStmt':
+        this.scanExpr(stmt.subject);
+        for (const arm of stmt.arms) {
+          if (arm.body.kind === 'Block') this.scanBlock(arm.body);
+          else this.scanExpr(arm.body);
+        }
+        break;
+      case 'SpawnStmt':
+        for (const a of stmt.args) this.scanExpr(a);
+        break;
+      case 'DeployStmt':
+        for (const a of stmt.args) this.scanExpr(a.value);
+        break;
+    }
+  }
+
+  private scanExpr(expr: Expr): void {
+    switch (expr.kind) {
+      case 'StringLiteral':
+        this.checkLiteralString(expr.value, expr.span);
+        break;
+      case 'StringInterpolation':
+        this.checkInterpolation(expr);
+        break;
+      case 'Ident':
+        this.checkWeakRandom(expr.name, expr.span);
+        break;
+      case 'Path':
+        this.checkWeakRandom(expr.segments[expr.segments.length - 1] ?? '', expr.span);
+        break;
+      case 'Call':
+        this.checkCall(expr);
+        break;
+      case 'MethodCall':
+        this.checkMethodCall(expr);
+        break;
+      case 'Binary':
+        this.scanExpr(expr.left);
+        this.scanExpr(expr.right);
+        break;
+      case 'Unary':
+        this.scanExpr(expr.operand);
+        break;
+      case 'FieldAccess':
+        this.scanExpr(expr.object);
+        break;
+      case 'Index':
+        this.scanExpr(expr.object);
+        this.scanExpr(expr.index);
+        break;
+      case 'Struct':
+        for (const f of expr.fields) {
+          // struct field literals can also hold secrets
+          if (
+            SECRET_NAME_RE.test(f.name) &&
+            f.value.kind === 'StringLiteral' &&
+            f.value.value.length >= 8
+          ) {
+            this.report({
+              code: 'SEC001',
+              category: 'hardcoded_secret',
+              severity: 'high',
+              message: `Hardcoded credential in struct field '${f.name}'`,
+              span: f.span,
+              suggestion: 'Load secrets from env/secret-store, never commit literals.',
+            });
+          }
+          this.scanExpr(f.value);
+        }
+        break;
+      case 'BlockExpr':
+        this.scanBlock(expr.block);
+        break;
+      case 'IfExpr':
+        this.scanExpr(expr.condition);
+        this.scanBlock(expr.then);
+        if (expr.else_) {
+          if (expr.else_.kind === 'IfExpr') this.scanExpr(expr.else_);
+          else this.scanBlock(expr.else_);
+        }
+        break;
+      case 'MatchExpr':
+        this.scanExpr(expr.subject);
+        for (const arm of expr.arms) {
+          if (arm.body.kind === 'Block') this.scanBlock(arm.body);
+          else this.scanExpr(arm.body);
+        }
+        break;
+      case 'Parallel':
+        this.scanBlock(expr.body);
+        break;
+      case 'Scope':
+        this.scanExpr(expr.initializer);
+        this.scanBlock(expr.body);
+        break;
+      case 'MacroCall':
+        for (const a of expr.args) this.scanExpr(a);
+        break;
+      case 'Range':
+        if (expr.start) this.scanExpr(expr.start);
+        if (expr.end) this.scanExpr(expr.end);
+        break;
+      case 'ArrayLiteral':
+        for (const e of expr.elements) this.scanExpr(e);
+        break;
+      case 'Closure':
+        if (expr.body.kind === 'Block') this.scanBlock(expr.body);
+        else this.scanExpr(expr.body);
+        break;
+      // IntLiteral / FloatLiteral / BoolLiteral — nothing to inspect
+      default:
+        break;
+    }
+  }
+
+  // ─── Specific checks ─────────────────────────────────────────
+
+  private checkHardcodedSecret(stmt: LetStmt): void {
+    if (!SECRET_NAME_RE.test(stmt.name)) return;
+    const init = stmt.initializer;
+    if (init.kind !== 'StringLiteral') return;
+    if (init.value.length < 8) return;
+    // Skip common placeholders
+    if (/^(changeme|placeholder|todo|xxx|none|null|undefined|example)$/i.test(init.value)) return;
+    this.report({
+      code: 'SEC001',
+      category: 'hardcoded_secret',
+      severity: 'high',
+      message: `Hardcoded secret in variable '${stmt.name}'`,
+      span: stmt.span,
+      suggestion: 'Load from env/secret-store, never commit literals to source.',
+    });
+  }
+
+  private checkCall(expr: CallExpr): void {
+    const name = calleeName(expr.callee);
+    if (name) {
+      const lower = name.toLowerCase();
+
+      if (WEAK_CRYPTO.has(lower)) {
+        this.report({
+          code: 'SEC002',
+          category: 'weak_crypto',
+          severity: 'high',
+          message: `Cryptographically broken primitive '${name}' in use`,
+          span: expr.span,
+          suggestion: 'Use SHA-256+ for hashing, AES-GCM/ChaCha20 for encryption.',
+        });
+      }
+
+      if (DANGEROUS_EVAL.has(lower)) {
+        const dynamic = expr.args.some(a => !isStaticString(a.value));
+        this.report({
+          code: 'SEC003',
+          category: 'dangerous_eval',
+          severity: dynamic ? 'critical' : 'medium',
+          message: dynamic
+            ? `'${name}' invoked with non-literal argument — potential code/command injection`
+            : `'${name}' is a dynamic-execution sink; review whether it is needed`,
+          span: expr.span,
+          suggestion: 'Replace with a typed API; if unavoidable, validate inputs against an allow-list.',
+        });
+      }
+
+      if (SQL_FUNCS.has(lower)) {
+        for (const arg of expr.args) {
+          if (containsStringConcat(arg.value)) {
+            this.report({
+              code: 'SEC006',
+              category: 'sql_concat',
+              severity: 'critical',
+              message: `SQL string concatenation passed to '${name}' — likely SQL injection`,
+              span: arg.value.span,
+              suggestion: 'Use parameterized queries / prepared statements.',
+            });
+          }
+        }
+      }
+    }
+    this.scanExpr(expr.callee);
+    for (const a of expr.args) this.scanExpr(a.value);
+  }
+
+  private checkMethodCall(expr: MethodCallExpr): void {
+    const lower = expr.method.toLowerCase();
+
+    if (WEAK_CRYPTO.has(lower)) {
+      this.report({
+        code: 'SEC002',
+        category: 'weak_crypto',
+        severity: 'high',
+        message: `Cryptographically broken primitive '.${expr.method}()' in use`,
+        span: expr.span,
+        suggestion: 'Use SHA-256+ for hashing, AES-GCM/ChaCha20 for encryption.',
+      });
+    }
+
+    if (DANGEROUS_EVAL.has(lower)) {
+      const dynamic = expr.args.some(a => !isStaticString(a.value));
+      this.report({
+        code: 'SEC003',
+        category: 'dangerous_eval',
+        severity: dynamic ? 'critical' : 'medium',
+        message: dynamic
+          ? `'.${expr.method}()' invoked with non-literal argument — potential code/command injection`
+          : `'.${expr.method}()' is a dynamic-execution sink; review whether it is needed`,
+        span: expr.span,
+        suggestion: 'Replace with a typed API; if unavoidable, validate inputs against an allow-list.',
+      });
+    }
+
+    if (SQL_FUNCS.has(lower)) {
+      for (const arg of expr.args) {
+        if (containsStringConcat(arg.value)) {
+          this.report({
+            code: 'SEC006',
+            category: 'sql_concat',
+            severity: 'critical',
+            message: `SQL string concatenation passed to '.${expr.method}()' — likely SQL injection`,
+            span: arg.value.span,
+            suggestion: 'Use parameterized queries / prepared statements.',
+          });
+        }
+      }
+    }
+
+    this.scanExpr(expr.object);
+    for (const a of expr.args) this.scanExpr(a.value);
+  }
+
+  private checkWeakRandom(name: string, span: Span): void {
+    if (WEAK_RANDOM.has(name.toLowerCase())) {
+      this.report({
+        code: 'SEC007',
+        category: 'weak_random',
+        severity: 'medium',
+        message: `'${name}' is not cryptographically secure`,
+        span,
+        suggestion: 'Use Crypto.random / SecureRandom for tokens, keys and nonces.',
+      });
+    }
+  }
+
+  private checkLiteralString(value: string, span: Span): void {
+    // SEC004 — cleartext URL
+    if (/\bhttp:\/\//i.test(value)) {
+      const allowed = CLEARTEXT_ALLOWLIST.some(p => value.toLowerCase().includes(p));
+      if (!allowed) {
+        this.report({
+          code: 'SEC004',
+          category: 'insecure_url',
+          severity: 'medium',
+          message: 'Cleartext http:// URL — traffic is unencrypted and tamperable',
+          span,
+          suggestion: 'Use https:// or constrain to localhost for development only.',
+        });
+      }
+    }
+    // SEC005 — path traversal
+    if (/(^|[\\/])\.\.([\\/]|$)/.test(value)) {
+      this.report({
+        code: 'SEC005',
+        category: 'path_traversal',
+        severity: 'high',
+        message: 'Literal path contains a ".." segment — potential path traversal',
+        span,
+        suggestion: 'Canonicalize paths and validate against an allow-listed root directory.',
+      });
+    }
+    // SEC008 — security TODO
+    if (TODO_SEC_RE.test(value)) {
+      this.report({
+        code: 'SEC008',
+        category: 'todo_security',
+        severity: 'low',
+        message: 'Security-related TODO/FIXME left in source',
+        span,
+        suggestion: 'Resolve before shipping; security TODOs become tomorrow\u2019s incidents.',
+      });
+    }
+  }
+
+  private checkInterpolation(expr: StringInterpolationExpr): void {
+    for (const part of expr.parts) {
+      if (part.kind === 'Literal') this.checkLiteralString(part.value, expr.span);
+      else this.scanExpr(part.expr);
+    }
+  }
+
+  // ─── Reporting ───────────────────────────────────────────────
+
+  private report(f: Finding): void {
+    this.findings.push(f);
+  }
+}
+
+// ─── AST helpers ─────────────────────────────────────────────────
+
+function calleeName(expr: Expr): string | null {
+  if (expr.kind === 'Ident') return expr.name;
+  if (expr.kind === 'Path') return expr.segments[expr.segments.length - 1] ?? null;
+  if (expr.kind === 'FieldAccess') return expr.field;
+  return null;
+}
+
+/** A static string is a plain literal with no dynamic parts. */
+function isStaticString(expr: Expr): boolean {
+  if (expr.kind === 'StringLiteral') return true;
+  if (expr.kind === 'StringInterpolation') {
+    return expr.parts.every(p => p.kind === 'Literal');
+  }
+  return false;
+}
+
+/**
+ * True when the expression mixes a string literal with non-literal data.
+ * Catches both `"SELECT ... " + name` and interpolated strings with `${expr}`.
+ */
+function containsStringConcat(expr: Expr): boolean {
+  if (expr.kind === 'Binary' && expr.operator === '+') {
+    const l = expr.left;
+    const r = expr.right;
+    const leftIsLit = l.kind === 'StringLiteral' || isStaticString(l);
+    const rightIsLit = r.kind === 'StringLiteral' || isStaticString(r);
+    if ((leftIsLit && !rightIsLit) || (!leftIsLit && rightIsLit)) return true;
+    return containsStringConcat(l) || containsStringConcat(r);
+  }
+  if (expr.kind === 'StringInterpolation') {
+    const hasLiteral = expr.parts.some(p => p.kind === 'Literal' && p.value.length > 0);
+    const hasDynamic = expr.parts.some(p => p.kind === 'Expr');
+    return hasLiteral && hasDynamic;
+  }
+  return false;
+}
+
+// ─── Scoring helper used by the audit command ────────────────────
+
+export function severityWeight(s: Severity): number {
+  switch (s) {
+    case 'critical': return 5;
+    case 'high':     return 3;
+    case 'medium':   return 2;
+    case 'low':      return 1;
+    case 'info':     return 0;
+  }
+}

--- a/compiler/src/cli.ts
+++ b/compiler/src/cli.ts
@@ -26,6 +26,8 @@ import { createInterface } from 'node:readline';
 import { Lexer, TokenType, Parser, formatDiagnostic, createError, VERSION } from './index.js';
 import { Resolver } from './semantic/index.js';
 import { Checker, OwnershipChecker, RefinementChecker, IntentChecker, EffectChecker } from './checker/index.js';
+import { scanPatterns, severityWeight } from './audit/index.js';
+import type { Finding } from './audit/index.js';
 import type { Program, TopLevelItem } from './ast/index.js';
 
 function main(): void {
@@ -105,14 +107,31 @@ function main(): void {
       process.exit(0);
       break;
 
-    case 'audit':
-      if (!file) {
+    case 'audit': {
+      const fmtIdx = args.indexOf('--format');
+      const format = fmtIdx >= 0 ? (args[fmtIdx + 1] ?? 'text') : 'text';
+      // Strip the command name and any --format <val> pair, take the first positional as the file.
+      const positional = args.slice(1).filter((a, i) => {
+        const absIdx = i + 1;
+        if (absIdx === fmtIdx || absIdx === fmtIdx + 1) return false;
+        return !a.startsWith('-');
+      });
+      const auditFile = positional[0];
+      if (!auditFile) {
         console.error('Error: missing file argument');
-        console.error('Usage: cbang audit <file.cb>');
+        console.error('Usage: cbang audit [--format text|json|sarif] <file.cb>');
         process.exit(1);
       }
-      auditCommand(file);
+      switch (format) {
+        case 'text': auditCommand(auditFile); break;
+        case 'json': auditJsonCommand(auditFile); break;
+        case 'sarif': auditSarifCommand(auditFile); break;
+        default:
+          console.error(`Unknown audit format: ${format} (expected text|json|sarif)`);
+          process.exit(1);
+      }
       break;
+    }
 
     default:
       console.error(`Unknown command: ${command}`);
@@ -667,7 +686,8 @@ COMMANDS:
   build --target near <file.cb>  Compile to NEAR WASM
   repl                Interactive REPL
   verify <file.cb>    Formal verification [not yet implemented]
-  audit <file.cb>     Security audit report
+  audit [--format text|json|sarif] <file.cb>
+                       Security audit report (default: text)
 
 OPTIONS:
   --version, -v       Show version
@@ -928,12 +948,24 @@ function auditCommand(filePath: string): void {
   results['intent']    = runChecker(() => new IntentChecker().check(program));
   results['effects']   = runChecker(() => new EffectChecker().check(program));
 
-  const allOk      = Object.values(results).every(r => r.ok);
+  // ── Pattern-based vulnerability scan ───────────────────────────────────────
+  let findings: Finding[] = [];
+  try { findings = scanPatterns(program); } catch { findings = []; }
+  const findingCounts = {
+    critical: findings.filter(f => f.severity === 'critical').length,
+    high:     findings.filter(f => f.severity === 'high').length,
+    medium:   findings.filter(f => f.severity === 'medium').length,
+    low:      findings.filter(f => f.severity === 'low').length,
+    info:     findings.filter(f => f.severity === 'info').length,
+  };
+  const findingsWeight = findings.reduce((s, f) => s + severityWeight(f.severity), 0);
+
+  const allOk      = Object.values(results).every(r => r.ok) && findingCounts.critical === 0 && findingCounts.high === 0;
   const totalWarn  = Object.values(results).reduce((s, r) => s + r.warnings, 0);
   const totalErr   = Object.values(results).reduce((s, r) => s + r.errors,   0);
 
   // ── Score (0-10) ─────────────────────────────────────────────────────────
-  const score = Math.max(0, 10 - totalErr * 2 - Math.floor(totalWarn / 2));
+  const score = Math.max(0, 10 - totalErr * 2 - Math.floor(totalWarn / 2) - findingsWeight);
 
   // ╔══════════════════════════════════════════════════════════════════╗
   const W = 66;
@@ -1008,6 +1040,38 @@ function auditCommand(filePath: string): void {
     console.log(`  ${g('✓')} ${vuln.padEnd(20)} ${statusStr}  ${d(detail)}`);
   }
 
+  // ── DETECTED ISSUES ─────────────────────────────────────────────────────────
+  console.log('');
+  console.log(c(`  ── DETECTED ISSUES ${line.slice(20)}`));
+  if (findings.length === 0) {
+    console.log(`  ${g('✓')} no vulnerable patterns detected by the scanner`);
+  } else {
+    const severityChip = (sev: Finding['severity']) => {
+      switch (sev) {
+        case 'critical': return `${C.bgRed}${C.bold} CRITICAL ${C.reset}`;
+        case 'high':     return `${C.red}${C.bold}HIGH    ${C.reset}`;
+        case 'medium':   return `${C.yellow}${C.bold}MEDIUM  ${C.reset}`;
+        case 'low':      return `${C.cyan}LOW     ${C.reset}`;
+        case 'info':     return d('INFO    ');
+      }
+    };
+    for (const f of findings) {
+      const loc = `${filePath}:${f.span.start.line}:${f.span.start.column}`;
+      console.log(`  ${severityChip(f.severity)} ${b(f.code)} ${f.message}`);
+      console.log(`           ${d(loc)}`);
+      if (f.suggestion) console.log(`           ${d('→ ' + f.suggestion)}`);
+    }
+    console.log('');
+    const counts = [
+      findingCounts.critical && `${C.red}${findingCounts.critical} critical${C.reset}`,
+      findingCounts.high     && `${C.red}${findingCounts.high} high${C.reset}`,
+      findingCounts.medium   && `${C.yellow}${findingCounts.medium} medium${C.reset}`,
+      findingCounts.low      && `${findingCounts.low} low`,
+      findingCounts.info     && `${findingCounts.info} info`,
+    ].filter(Boolean).join(', ');
+    console.log(`  ${b('Totals:')} ${counts}`);
+  }
+
   // ── CHECKER RESULTS ────────────────────────────────────────────────────────
   console.log('');
   console.log(c(`  ── CHECKER RESULTS ${line.slice(20)}`));
@@ -1037,22 +1101,228 @@ function auditCommand(filePath: string): void {
 
   const impossible = vulns.filter(([, s]) => s === 'IMPOSSIBLE').length;
 
-  if (allOk && totalErr === 0) {
+  const blockingFindings = findingCounts.critical + findingCounts.high;
+
+  if (allOk && totalErr === 0 && blockingFindings === 0) {
     const star = score >= 9 ? '★★★★★' : score >= 7 ? '★★★★☆' : '★★★☆☆';
     console.log(`  ${b(g(`Audit score: ${score}/10  ${star}  SECURE`))}`);
     console.log(`  ${g(`${impossible} vulnerability classes are structurally impossible in this file.`)}`);
+    if (findingCounts.medium + findingCounts.low > 0) {
+      console.log(`  ${y(`${findingCounts.medium + findingCounts.low} non-blocking finding${findingCounts.medium + findingCounts.low > 1 ? 's' : ''} — review recommended`)}`);
+    }
   } else {
     console.log(`  ${b(`${C.red}Audit score: ${score}/10  — FIX REQUIRED${C.reset}`)}`);
-    console.log(`  ${`${C.red}${totalErr} error${totalErr > 1 ? 's' : ''} found. Run 'cbang check ${filePath}' for details.${C.reset}`}`);
+    if (totalErr > 0) {
+      console.log(`  ${`${C.red}${totalErr} checker error${totalErr > 1 ? 's' : ''} — run 'cbang check ${filePath}' for details.${C.reset}`}`);
+    }
+    if (blockingFindings > 0) {
+      console.log(`  ${`${C.red}${blockingFindings} blocking finding${blockingFindings > 1 ? 's' : ''} (critical/high) detected by audit scanner.${C.reset}`}`);
+    }
   }
 
   if (totalWarn > 0) {
-    console.log(`  ${y(`${totalWarn} warning${totalWarn > 1 ? 's' : ''} — review recommended`)}`);
+    console.log(`  ${y(`${totalWarn} warning${totalWarn > 1 ? 's' : ''} from checkers`)}`);
   }
 
   console.log('');
 
-  process.exit(allOk ? 0 : 1);
+  process.exit(allOk && totalErr === 0 && blockingFindings === 0 ? 0 : 1);
+}
+
+// ─── audit: structured output (JSON / SARIF) ───────────────────────────────
+
+interface AuditCheckerResult {
+  ok: boolean;
+  warnings: number;
+  errors: number;
+}
+
+interface AuditScanData {
+  filePath: string;
+  source: string;
+  findings: Finding[];
+  checkers: Record<string, AuditCheckerResult>;
+  totalErrors: number;
+  totalWarnings: number;
+  blockingFindings: number;
+  score: number;
+}
+
+/** Run lex/parse/all checkers + pattern scan and collect results. */
+function collectAuditData(filePath: string): AuditScanData {
+  const source = readSource(filePath);
+  const tokens = new Lexer(source, filePath).tokenize();
+  const lexErrors = tokens.filter(t => t.type === TokenType.Error).length;
+
+  const parser = new Parser(tokens);
+  const { program, diagnostics: parseDiags } = parser.parse();
+
+  const runChecker = (fn: () => { severity: string }[]): AuditCheckerResult => {
+    try {
+      const diags = fn();
+      return {
+        ok: diags.filter(d => d.severity === 'error').length === 0,
+        errors: diags.filter(d => d.severity === 'error').length,
+        warnings: diags.filter(d => d.severity === 'warning').length,
+      };
+    } catch {
+      return { ok: false, warnings: 0, errors: 1 };
+    }
+  };
+
+  const resolver = new Resolver();
+  const nameDiags = resolver.resolve(program);
+
+  const checkers: Record<string, AuditCheckerResult> = {
+    lexer:      { ok: lexErrors === 0, warnings: 0, errors: lexErrors },
+    parser:     { ok: parseDiags.length === 0, warnings: 0, errors: parseDiags.length },
+    nameResolver: { ok: nameDiags.length === 0, warnings: 0, errors: nameDiags.length },
+    types:      runChecker(() => new Checker().check(program)),
+    ownership:  runChecker(() => new OwnershipChecker().check(program)),
+    refinement: runChecker(() => new RefinementChecker().check(program)),
+    intent:     runChecker(() => new IntentChecker().check(program)),
+    effects:    runChecker(() => new EffectChecker().check(program)),
+  };
+
+  let findings: Finding[] = [];
+  try { findings = scanPatterns(program); } catch { findings = []; }
+
+  const totalErrors = Object.values(checkers).reduce((s, r) => s + r.errors, 0);
+  const totalWarnings = Object.values(checkers).reduce((s, r) => s + r.warnings, 0);
+  const findingsWeight = findings.reduce((s, f) => s + severityWeight(f.severity), 0);
+  const blockingFindings = findings.filter(f => f.severity === 'critical' || f.severity === 'high').length;
+  const score = Math.max(0, 10 - totalErrors * 2 - Math.floor(totalWarnings / 2) - findingsWeight);
+
+  return { filePath, source, findings, checkers, totalErrors, totalWarnings, blockingFindings, score };
+}
+
+/** Map cbang severity → SARIF level. */
+function sarifLevel(sev: Finding['severity']): 'error' | 'warning' | 'note' {
+  if (sev === 'critical' || sev === 'high') return 'error';
+  if (sev === 'medium') return 'warning';
+  return 'note';
+}
+
+/** Stable list of all rules emitted by the pattern scanner (for SARIF rules section). */
+const SARIF_RULES: ReadonlyArray<{ id: string; name: string; shortDescription: string; helpText: string }> = [
+  { id: 'SEC001', name: 'hardcoded_secret',  shortDescription: 'Hardcoded credential bound to a credential-named identifier.', helpText: 'Load secrets from env/secret-store, never commit literals.' },
+  { id: 'SEC002', name: 'weak_crypto',       shortDescription: 'Use of cryptographically broken primitive (MD5/SHA1/DES/RC4).', helpText: 'Use SHA-256+ for hashing, AES-GCM/ChaCha20 for encryption.' },
+  { id: 'SEC003', name: 'dangerous_eval',    shortDescription: 'Dynamic-execution sink (eval/exec/system) — possible code/command injection.', helpText: 'Replace with typed APIs; validate inputs against an allow-list.' },
+  { id: 'SEC004', name: 'insecure_url',      shortDescription: 'Cleartext http:// URL — traffic is unencrypted and tamperable.', helpText: 'Use https:// or constrain to localhost for development only.' },
+  { id: 'SEC005', name: 'path_traversal',    shortDescription: 'Literal path contains a ".." segment — potential path traversal.', helpText: 'Canonicalize paths and validate against an allow-listed root.' },
+  { id: 'SEC006', name: 'sql_concat',        shortDescription: 'SQL string concatenation passed to a query sink — likely SQL injection.', helpText: 'Use parameterized queries / prepared statements.' },
+  { id: 'SEC007', name: 'weak_random',       shortDescription: 'Non-cryptographic randomness used where CSPRNG is expected.', helpText: 'Use Crypto.random / SecureRandom for tokens, keys and nonces.' },
+  { id: 'SEC008', name: 'todo_security',     shortDescription: 'Security-related TODO/FIXME left in source.', helpText: 'Resolve before shipping; security TODOs become incidents.' },
+];
+
+function auditAsJson(data: AuditScanData): unknown {
+  const { filePath, findings, checkers, totalErrors, totalWarnings, blockingFindings, score } = data;
+  return {
+    tool: { name: 'cbang audit', version: VERSION },
+    file: filePath,
+    score,
+    pass: data.checkers.lexer.ok
+      && checkers.parser.ok
+      && checkers.nameResolver.ok
+      && checkers.types.ok
+      && totalErrors === 0
+      && blockingFindings === 0,
+    summary: {
+      checkerErrors: totalErrors,
+      checkerWarnings: totalWarnings,
+      blockingFindings,
+      totalFindings: findings.length,
+      bySeverity: {
+        critical: findings.filter(f => f.severity === 'critical').length,
+        high:     findings.filter(f => f.severity === 'high').length,
+        medium:   findings.filter(f => f.severity === 'medium').length,
+        low:      findings.filter(f => f.severity === 'low').length,
+        info:     findings.filter(f => f.severity === 'info').length,
+      },
+    },
+    checkers,
+    findings: findings.map(f => ({
+      code: f.code,
+      category: f.category,
+      severity: f.severity,
+      message: f.message,
+      suggestion: f.suggestion,
+      location: {
+        file: f.span.file,
+        startLine: f.span.start.line,
+        startColumn: f.span.start.column,
+        endLine: f.span.end.line,
+        endColumn: f.span.end.column,
+      },
+    })),
+  };
+}
+
+function auditAsSarif(data: AuditScanData): unknown {
+  const { filePath, findings } = data;
+  const fileUri = filePath.startsWith('/')
+    ? `file://${filePath}`
+    : filePath;
+
+  return {
+    $schema: 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
+    version: '2.1.0',
+    runs: [{
+      tool: {
+        driver: {
+          name: 'cbang-audit',
+          version: VERSION,
+          informationUri: 'https://github.com/integsec/C-Bang',
+          rules: SARIF_RULES.map(r => ({
+            id: r.id,
+            name: r.name,
+            shortDescription: { text: r.shortDescription },
+            help: { text: r.helpText },
+            defaultConfiguration: {
+              level: r.id === 'SEC003' || r.id === 'SEC006' ? 'error'
+                   : r.id === 'SEC008' || r.id === 'SEC007' || r.id === 'SEC004' ? 'warning'
+                   : 'error',
+            },
+          })),
+        },
+      },
+      results: findings.map(f => ({
+        ruleId: f.code,
+        level: sarifLevel(f.severity),
+        message: { text: f.message + (f.suggestion ? ` (suggestion: ${f.suggestion})` : '') },
+        locations: [{
+          physicalLocation: {
+            artifactLocation: { uri: fileUri },
+            region: {
+              startLine: f.span.start.line,
+              startColumn: f.span.start.column,
+              endLine: f.span.end.line,
+              endColumn: f.span.end.column,
+            },
+          },
+        }],
+        properties: { severity: f.severity, category: f.category },
+      })),
+      invocations: [{
+        executionSuccessful: data.totalErrors === 0,
+        exitCode: data.totalErrors === 0 && data.blockingFindings === 0 ? 0 : 1,
+      }],
+    }],
+  };
+}
+
+function auditJsonCommand(filePath: string): void {
+  const data = collectAuditData(filePath);
+  process.stdout.write(JSON.stringify(auditAsJson(data), null, 2) + '\n');
+  const exitCode = data.totalErrors === 0 && data.blockingFindings === 0 ? 0 : 1;
+  process.exit(exitCode);
+}
+
+function auditSarifCommand(filePath: string): void {
+  const data = collectAuditData(filePath);
+  process.stdout.write(JSON.stringify(auditAsSarif(data), null, 2) + '\n');
+  const exitCode = data.totalErrors === 0 && data.blockingFindings === 0 ? 0 : 1;
+  process.exit(exitCode);
 }
 
 function handleError(e: unknown): void {

--- a/compiler/tests/audit-patterns.test.ts
+++ b/compiler/tests/audit-patterns.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import { Lexer } from '../src/lexer/index.js';
+import { Parser } from '../src/parser/index.js';
+import { scanPatterns } from '../src/audit/patterns.js';
+import type { Finding } from '../src/audit/patterns.js';
+
+function scan(source: string): Finding[] {
+  const tokens = new Lexer(source, 'test.cb').tokenize();
+  const { program } = new Parser(tokens).parse();
+  return scanPatterns(program);
+}
+
+function codes(findings: Finding[]): string[] {
+  return findings.map(f => f.code);
+}
+
+describe('audit pattern scanner', () => {
+  // ─── SEC001 hardcoded secret ──────────────────────────────────
+
+  describe('SEC001 hardcoded secret', () => {
+    it('flags a string literal bound to a credential-named variable', () => {
+      const findings = scan(`
+        fn login() {
+          let api_key: String = "sk_live_abcdefghij";
+        }
+      `);
+      expect(codes(findings)).toContain('SEC001');
+      const f = findings.find(x => x.code === 'SEC001')!;
+      expect(f.severity).toBe('high');
+    });
+
+    it('flags assignment to a credential-named field', () => {
+      const findings = scan(`
+        fn cfg() {
+          config.password = "supersecret123";
+        }
+      `);
+      expect(codes(findings)).toContain('SEC001');
+    });
+
+    it('flags credential in a struct field', () => {
+      const findings = scan(`
+        fn make() {
+          let c: Config = Config { client_secret: "xyzxyzxyzxyz" };
+        }
+      `);
+      expect(codes(findings)).toContain('SEC001');
+    });
+
+    it('does not flag short or placeholder values', () => {
+      const findings = scan(`
+        fn skip() {
+          let password: String = "changeme";
+          let api_key: String = "todo";
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC001');
+    });
+
+    it('does not flag non-credential variable names', () => {
+      const findings = scan(`
+        fn ok() {
+          let greeting: String = "Hello world!";
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC001');
+    });
+  });
+
+  // ─── SEC002 weak crypto ───────────────────────────────────────
+
+  describe('SEC002 weak crypto', () => {
+    it('flags an md5 call', () => {
+      const findings = scan(`
+        fn hash() {
+          let h: String = md5("hello");
+        }
+      `);
+      expect(codes(findings)).toContain('SEC002');
+    });
+
+    it('flags a .sha1() method call', () => {
+      const findings = scan(`
+        fn hash(data: Bytes) {
+          let h: Bytes = data.sha1();
+        }
+      `);
+      expect(codes(findings)).toContain('SEC002');
+    });
+
+    it('does not flag sha256', () => {
+      const findings = scan(`
+        fn hash() {
+          let h: String = sha256("hello");
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC002');
+    });
+  });
+
+  // ─── SEC003 dangerous eval ────────────────────────────────────
+
+  describe('SEC003 dangerous eval', () => {
+    it('marks eval with non-literal argument as critical', () => {
+      const findings = scan(`
+        fn run(input: String) {
+          eval(input);
+        }
+      `);
+      const f = findings.find(x => x.code === 'SEC003');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('critical');
+    });
+
+    it('marks system() with literal as medium (still flagged)', () => {
+      const findings = scan(`
+        fn boot() {
+          system("ls");
+        }
+      `);
+      const f = findings.find(x => x.code === 'SEC003');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('medium');
+    });
+  });
+
+  // ─── SEC004 cleartext URL ─────────────────────────────────────
+
+  describe('SEC004 insecure URL', () => {
+    it('flags an http:// URL literal', () => {
+      const findings = scan(`
+        fn req() {
+          let url: String = "http://api.example.net/login";
+        }
+      `);
+      expect(codes(findings)).toContain('SEC004');
+    });
+
+    it('does not flag https://', () => {
+      const findings = scan(`
+        fn req() {
+          let url: String = "https://api.example.net/login";
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC004');
+    });
+
+    it('does not flag http://localhost', () => {
+      const findings = scan(`
+        fn req() {
+          let url: String = "http://localhost:8080";
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC004');
+    });
+  });
+
+  // ─── SEC005 path traversal ────────────────────────────────────
+
+  describe('SEC005 path traversal', () => {
+    it('flags a literal containing ..', () => {
+      const findings = scan(`
+        fn read() {
+          let p: String = "../../etc/passwd";
+        }
+      `);
+      expect(codes(findings)).toContain('SEC005');
+    });
+
+    it('does not flag a normal path', () => {
+      const findings = scan(`
+        fn read() {
+          let p: String = "data/users.json";
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC005');
+    });
+  });
+
+  // ─── SEC006 SQL concatenation ─────────────────────────────────
+
+  describe('SEC006 SQL concat', () => {
+    it('flags string concat passed to query()', () => {
+      const findings = scan(`
+        fn list(name: String) {
+          query("SELECT * FROM users WHERE name = '" + name + "'");
+        }
+      `);
+      expect(codes(findings)).toContain('SEC006');
+    });
+
+    it('flags string concat passed via .execute()', () => {
+      const findings = scan(`
+        fn list(name: String) {
+          db.execute("SELECT * FROM users WHERE name = '" + name + "'");
+        }
+      `);
+      expect(codes(findings)).toContain('SEC006');
+    });
+
+    it('flags interpolated SQL string', () => {
+      const findings = scan(`
+        fn list(name: String) {
+          query("SELECT * FROM users WHERE name = '\${name}'");
+        }
+      `);
+      expect(codes(findings)).toContain('SEC006');
+    });
+
+    it('does not flag a static SQL literal', () => {
+      const findings = scan(`
+        fn list() {
+          query("SELECT * FROM users");
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC006');
+    });
+  });
+
+  // ─── SEC007 weak random ───────────────────────────────────────
+
+  describe('SEC007 weak random', () => {
+    it('flags a bare rand call', () => {
+      const findings = scan(`
+        fn token() {
+          let t: i64 = rand();
+        }
+      `);
+      expect(codes(findings)).toContain('SEC007');
+    });
+  });
+
+  // ─── SEC008 security TODO ─────────────────────────────────────
+
+  describe('SEC008 security TODO', () => {
+    it('flags TODO/FIXME mentioning security keywords', () => {
+      const findings = scan(`
+        fn note() {
+          let msg: String = "TODO: sanitize the user input before saving";
+        }
+      `);
+      expect(codes(findings)).toContain('SEC008');
+    });
+
+    it('does not flag generic TODOs', () => {
+      const findings = scan(`
+        fn note() {
+          let msg: String = "TODO: refactor this later";
+        }
+      `);
+      expect(codes(findings)).not.toContain('SEC008');
+    });
+  });
+
+  // ─── Coverage / structure ─────────────────────────────────────
+
+  describe('AST coverage', () => {
+    it('returns no findings for clean code', () => {
+      const findings = scan(`
+        fn add(a: i64, b: i64) -> i64 {
+          return a + b;
+        }
+      `);
+      expect(findings).toHaveLength(0);
+    });
+
+    it('walks into actor handlers', () => {
+      const findings = scan(`
+        actor Auth {
+          on login(pw: String) {
+            let h: String = md5(pw);
+          }
+        }
+      `);
+      expect(codes(findings)).toContain('SEC002');
+    });
+
+    it('walks into contract methods', () => {
+      const findings = scan(`
+        contract Token {
+          fn check() {
+            eval("dangerous");
+          }
+        }
+      `);
+      expect(codes(findings)).toContain('SEC003');
+    });
+
+    it('produces deterministic ordering by file position', () => {
+      const findings = scan(`
+        fn first() {
+          let api_key: String = "AAAAAAAA12345";
+        }
+        fn second() {
+          let password: String = "BBBBBBBB67890";
+        }
+      `);
+      const lines = findings.filter(f => f.code === 'SEC001').map(f => f.span.start.line);
+      expect(lines).toEqual([...lines].sort((a, b) => a - b));
+    });
+  });
+});

--- a/examples/security/clean.cb
+++ b/examples/security/clean.cb
@@ -1,0 +1,27 @@
+// Same intent as vulnerable.cb but written using safe primitives.
+// `cbang audit` should report zero findings for this file.
+//
+// Run:  cbang audit examples/security/clean.cb
+
+fn login(name: String, supplied: String) with Database, Network, Crypto {
+    // Secrets come from the environment, never from source.
+    let api_key: String = env_var("STRIPE_API_KEY");
+
+    // Modern hash function.
+    let stored: String = sha256(supplied);
+
+    // TLS endpoint.
+    let endpoint: String = "https://auth.example.net/v1/login";
+
+    // Parameterized query — no string concat.
+    query_params("SELECT * FROM users WHERE name = ?", name);
+
+    // CSPRNG-backed token.
+    let token: Bytes = secure_random_bytes(32);
+
+    // Typed argv, no shell interpolation.
+    run_argv("login", name);
+
+    // Safe path joined under a known root.
+    let log_path: String = safe_join("/var/log/app", "current.log");
+}

--- a/examples/security/vulnerable.cb
+++ b/examples/security/vulnerable.cb
@@ -1,0 +1,30 @@
+// Deliberately vulnerable file used to demonstrate `cbang audit`.
+// Every issue here should be flagged by the pattern scanner.
+//
+// Run:  cbang audit examples/security/vulnerable.cb
+
+fn login(name: String, supplied: String) {
+    // SEC001 — credential committed to source
+    let api_key: String = "EXAMPLE_NOT_A_REAL_KEY_DO_NOT_USE";
+
+    // SEC002 — broken hash function
+    let stored: String = md5(supplied);
+
+    // SEC004 — cleartext transport for an auth call
+    let endpoint: String = "http://auth.example.net/v1/login";
+
+    // SEC006 — SQL injection through string concatenation
+    query("SELECT * FROM users WHERE name = '" + name + "'");
+
+    // SEC007 — non-cryptographic randomness used for a token
+    let token: i64 = rand();
+
+    // SEC003 — dynamic shell execution with user-controlled input
+    system(name);
+
+    // SEC005 — path traversal literal
+    let log_path: String = "../../var/log/app.log";
+
+    // SEC008 — security TODO left in source
+    let note: String = "TODO: sanitize input before shell exec";
+}


### PR DESCRIPTION
## Summary
- Replaces the canned audit report with a real pattern scanner (SEC001-008: hardcoded secrets, weak crypto, dangerous eval, cleartext URLs, path traversal, SQL concat, weak randomness, security TODOs).
- Adds `--format sarif` (SARIF 2.1.0 for GitHub Code Scanning / any SAST) and `--format json` for CI/CD.
- Exit code 1 when critical/high findings or checker errors are present.
- Adds `examples/security/{vulnerable,clean}.cb`.

## Test plan
- [x] bun test — 789 pass / 0 fail (26 new tests).
- [x] bun run build — clean TS build.
- [x] audit on vulnerable.cb: 8 findings (2 critical / 3 high / 2 medium / 1 low).
- [x] --format sarif: valid SARIF 2.1.0 (8 rules / 8 results).
- [x] --format json: structured summary + per-finding detail.
- [x] audit on clean.cb: zero scanner findings.